### PR TITLE
smarter error handling for prayers, smart navbar

### DIFF
--- a/app/src/main/java/com/paradox543/malankaraorthodoxliturgica/data/model/PrayerElement.kt
+++ b/app/src/main/java/com/paradox543/malankaraorthodoxliturgica/data/model/PrayerElement.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonClassDiscriminator
 
-@Serializable
-@JsonClassDiscriminator("type")  // Use type field in the JSON to deserialize the object
+@Serializable(with= PrayerElementSerializer::class)
+//@JsonClassDiscriminator("type")  // Use type field in the JSON to deserialize the object
 sealed interface PrayerElement {
 
     // Simple data classes

--- a/app/src/main/java/com/paradox543/malankaraorthodoxliturgica/data/model/PrayerElementSerializer.kt
+++ b/app/src/main/java/com/paradox543/malankaraorthodoxliturgica/data/model/PrayerElementSerializer.kt
@@ -1,0 +1,95 @@
+package com.paradox543.malankaraorthodoxliturgica.data.model
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+object PrayerElementSerializer : KSerializer<PrayerElement> {
+    // Descriptor for the serializer itself. For polymorphic types, it's often simple.
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("PrayerElement")
+
+    // Define a Json instance for internal use by the serializer.
+    // It's important that this Json instance does NOT have `serializersModule` configured for PrayerElement,
+    // as this custom serializer *is* handling the polymorphism for PrayerElement.
+    private val json = Json {
+        // You might want to ignore unknown keys for the individual data classes
+        // so that if a PrayerElement subclass has extra fields, it doesn't crash.
+        ignoreUnknownKeys = true
+        // Set to true if your JSON might have relaxed syntax (e.g., unquoted keys)
+        isLenient = true
+        // If a field is nullable but the JSON has null, this helps
+        coerceInputValues = true
+        // If you had other sealed hierarchies, you might configure them here,
+        // but for PrayerElement itself, we handle it manually.
+    }
+
+    override fun deserialize(decoder: Decoder): PrayerElement {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw SerializationException("This serializer can only be used with JsonDecoder")
+
+        // 1. Decode the incoming JSON into a generic JsonObject
+        // This allows us to inspect its contents (like the 'type' field) first.
+        val element = jsonDecoder.decodeJsonElement().jsonObject
+
+        // 2. Extract the 'type' discriminator field
+        val type = element["type"]?.jsonPrimitive?.contentOrNull
+
+        // 3. Use a when expression to dispatch to the correct deserializer
+        return try {
+            when (type) {
+                "title" -> json.decodeFromJsonElement(PrayerElement.Title.serializer(), element)
+                "heading" -> json.decodeFromJsonElement(PrayerElement.Heading.serializer(), element)
+                "subheading" -> json.decodeFromJsonElement(PrayerElement.Subheading.serializer(), element)
+                "prose" -> json.decodeFromJsonElement(PrayerElement.Prose.serializer(), element)
+                "song" -> json.decodeFromJsonElement(PrayerElement.Song.serializer(), element)
+                "subtext" -> json.decodeFromJsonElement(PrayerElement.Subtext.serializer(), element)
+                "collapsible-block" -> json.decodeFromJsonElement(PrayerElement.CollapsibleBlock.serializer(), element)
+                "link" -> json.decodeFromJsonElement(PrayerElement.Link.serializer(), element)
+                "link-collapsible" -> json.decodeFromJsonElement(PrayerElement.LinkCollapsible.serializer(), element)
+                // If you explicitly serialize PrayerElement.Error in your JSON, handle it:
+                "error" -> json.decodeFromJsonElement(PrayerElement.Error.serializer(), element)
+
+                // --- Fallback for unknown types ---
+                else -> {
+                    // Create an Error element with informative content
+                    PrayerElement.Error("Unknown or invalid PrayerElement type: '$type'. Original JSON: ${element.toString()}")
+                }
+            }
+        } catch (e: Exception) {
+            // Catch any serialization exceptions that might occur even for known types
+            // (e.g., missing required fields, type mismatch for a property)
+            PrayerElement.Error("Error parsing PrayerElement '$type': ${e.message}. Original JSON: ${element.toString()}")
+        }
+    }
+
+    // --- Serialization part (to convert PrayerElement back to JSON) ---
+    // This is less critical for your current problem (reading JSON)
+    // but essential if you ever serialize PrayerElement objects back to JSON.
+    override fun serialize(encoder: Encoder, value: PrayerElement) {
+        val jsonEncoder = encoder as? JsonEncoder
+            ?: throw SerializationException("This serializer can only be used with JsonEncoder")
+
+        val jsonElement = when (value) {
+            is PrayerElement.Title -> json.encodeToJsonElement(PrayerElement.Title.serializer(), value)
+            is PrayerElement.Heading -> json.encodeToJsonElement(PrayerElement.Heading.serializer(), value)
+            is PrayerElement.Subheading -> json.encodeToJsonElement(PrayerElement.Subheading.serializer(), value)
+            is PrayerElement.Prose -> json.encodeToJsonElement(PrayerElement.Prose.serializer(), value)
+            is PrayerElement.Song -> json.encodeToJsonElement(PrayerElement.Song.serializer(), value)
+            is PrayerElement.Subtext -> json.encodeToJsonElement(PrayerElement.Subtext.serializer(), value)
+            is PrayerElement.CollapsibleBlock -> json.encodeToJsonElement(PrayerElement.CollapsibleBlock.serializer(), value)
+            is PrayerElement.Link -> json.encodeToJsonElement(PrayerElement.Link.serializer(), value)
+            is PrayerElement.LinkCollapsible -> json.encodeToJsonElement(PrayerElement.LinkCollapsible.serializer(), value)
+            is PrayerElement.Error -> json.encodeToJsonElement(PrayerElement.Error.serializer(), value)
+        }
+        jsonEncoder.encodeJsonElement(jsonElement)
+    }
+}

--- a/app/src/main/java/com/paradox543/malankaraorthodoxliturgica/view/PrayerScreen.kt
+++ b/app/src/main/java/com/paradox543/malankaraorthodoxliturgica/view/PrayerScreen.kt
@@ -10,13 +10,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
@@ -30,6 +26,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -94,6 +91,20 @@ fun PrayerScreen(
         LazyListState()
     }
 
+    // Observe if the LazyColumn has been scrolled to its very end
+    val isScrolledToTheEnd by remember {
+        derivedStateOf {
+            !listState.isScrollInProgress && !listState.canScrollForward // True if there's no more content to scroll down to
+        }
+    }
+
+    // React to the scroll state change
+    LaunchedEffect(isScrolledToTheEnd) {
+        if (isScrolledToTheEnd) {
+            isVisible.value = true // Make bars visible when scrolled to the end
+        }
+    }
+
     Scaffold(
         modifier = Modifier
             .nestedScroll(nestedScrollConnection)
@@ -137,26 +148,23 @@ fun PrayerScreen(
         Box(
             modifier = Modifier
                 .padding(horizontal = if (isLandscape) 40.dp else 20.dp) // Reduce width in landscape
-//                .padding(top = initialTopPadding.value)
                 .fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
             LazyColumn(
                 modifier = Modifier
                     .fillMaxWidth(if (isLandscape) 0.8f else 1f), // Limit width in landscape
-//                    .fillMaxHeight(0.9f), // Limit height to avoid out of bounds
                 state = listState,
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
+                listState.canScrollForward
                 item {
-//                    Spacer(Modifier.padding(if (isLandscape) 40.dp else 32.dp))
                     Spacer(Modifier.padding(top = initialTopPadding.value))
                 }
                 items(prayers) { prayerElement ->
                     PrayerElementRenderer(prayerElement, selectedFontSize)
                 }
                 item {
-//                    Spacer(Modifier.padding(if (isLandscape) 40.dp else 44.dp))
                     Spacer(Modifier.padding(bottom = initialBottomPadding.value))
                 }
             }


### PR DESCRIPTION
Wrong tags in prayer elements no longer cause the app to crash the moment they are encountered. Rather they are smartly raised as errors to allow for easier debugging. The nav bars are also made visible when user reaches the end of the screen.